### PR TITLE
Remove proguard file option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Travis CI config
+- Removed unused proguard file deploy option
 
 ## [2.6] - 2019-07-19
 

--- a/lib/shaman/cli.rb
+++ b/lib/shaman/cli.rb
@@ -37,13 +37,12 @@ module Shaman
       end
     end
 
-    def deploy # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def deploy # rubocop:disable Metrics/MethodLength
       command :deploy do |c|
         c.syntax = 'shaman deploy [environment]'
         c.description = 'Deploy a release to specified environment'
         c.option '-m', '--message MESSAGE', String, 'Changelog message'
         c.option '-f', '--file FILE', String, 'Release path'
-        c.option '-p', '--proguard FILE', String, 'Add aditional proguard mapping'
         c.option '-t', '--token TOKEN', String, 'Use different user token'
         c.option '-c', '--config FILE', String, 'Use different config file'
         c.option '-g', '--git', 'Use git for message (overrides any manual settings!)'


### PR DESCRIPTION
Task: --

## Description
Removed unused proguard file option for the deploy command.

## Checklist:
- [x] Specs are added or updated.
- [x] Changes follow the code style set by the shaman project.
- [x] CHANGELOG.md is updated.